### PR TITLE
Fixed active workspace selection on hyprland with named workspaces

### DIFF
--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -114,9 +114,13 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
         match hyprland.ipc.next_event() {
             Ok(event) => {
                 if let Some(active_ws) = event.strip_prefix("workspace>>") {
-                    let ws = hyprland.workspaces.iter().find(|ws| ws.name == active_ws).ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
-                    })?;
+                    let ws = hyprland
+                        .workspaces
+                        .iter()
+                        .find(|ws| ws.name == active_ws)
+                        .ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
+                        })?;
                     hyprland.active_id = ws.id;
                     updated = true;
                 } else if let Some(data) = event.strip_prefix("focusedmon>>") {
@@ -124,9 +128,13 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                         io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
                     })?;
 
-                    let ws = hyprland.workspaces.iter().find(|ws| ws.name == active_ws).ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
-                    })?;
+                    let ws = hyprland
+                        .workspaces
+                        .iter()
+                        .find(|ws| ws.name == active_ws)
+                        .ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
+                        })?;
                     hyprland.active_id = ws.id;
                     updated = true;
                 } else if event.contains("workspace>>") {

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -114,25 +114,21 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
         match hyprland.ipc.next_event() {
             Ok(event) => {
                 if let Some(active_ws) = event.strip_prefix("workspace>>") {
-                    match hyprland.workspaces.iter().find(|ws| ws.name == active_ws) {
-                        Some(ws) => {
-                            hyprland.active_id = ws.id;
-                            updated = true;
-                        }
-                        None => return Err(io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace"))
-                    }
+                    let ws = hyprland.workspaces.iter().find(|ws| ws.name == active_ws).ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
+                    })?;
+                    hyprland.active_id = ws.id;
+                    updated = true;
                 } else if let Some(data) = event.strip_prefix("focusedmon>>") {
                     let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
                         io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
                     })?;
 
-                    match hyprland.workspaces.iter().find(|ws| ws.name == active_ws) {
-                        Some(ws) => {
-                            hyprland.active_id = ws.id;
-                            updated = true;
-                        }
-                        None => return Err(io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace"))
-                    }
+                    let ws = hyprland.workspaces.iter().find(|ws| ws.name == active_ws).ok_or_else(|| {
+                        io::Error::new(io::ErrorKind::InvalidData, "Unknown workspace")
+                    })?;
+                    hyprland.active_id = ws.id;
+                    updated = true;
                 } else if event.contains("workspace>>") {
                     hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                     updated = true;


### PR DESCRIPTION
When using hyprland workspaces with default names, e.g. as configured the following in the hyprland config:
```
workspace = 1, defaultName=A
workspace = 2, defaultName=B
...
```
These names are then used in the IPC communication instead of the workspace IDs (e.g. `workspace>>A`, `focusedmon>>DP-1,A`).

But in the current state, `i3bar-river` expects the workspace ID to be used in these events, which then is used set the active workspace ID, which leads to the following error `invalid digit found in string`, as the name could be set to any string.

In my changes the string in the IPC events is used to retrieve the actual workspace ID by filtering the vector of workspaces by the provided name. 
Note that when no default name is specified in the hyprland config the ID is used a the name, so this does not break.
