### PR TITLE
Add support for special theme for unfocused outputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,8 +573,15 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pangocairo = "0.20"
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 signal-hook = { version = "0.3", default-features = false }
-toml = { version = "0.8", default-features = false, features = ["parse"] }
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 wayrs-client = "1.0"
 wayrs-protocols = { version = "0.14", features = ["wlr-layer-shell-unstable-v1", "viewporter", "fractional-scale-v1"] }
 wayrs-utils = { version = "0.17", features = ["cursor", "shm_alloc", "seats"] }

--- a/README.md
+++ b/README.md
@@ -40,64 +40,7 @@ riverctl spawn i3bar-river
 
 The configuration file should be stored in `$XDG_CONFIG_HOME/i3bar-river/config.toml` or `~/.config/i3bar-river/config.toml`.
 
-The default configuration (every parameter is optional):
-
-```toml
-# The status generator command.
-# Optional: with no status generator the bar will display only tags and layout name.
-# command = "your command here"
-
-# Colors
-background = "#282828ff"
-color = "#ffffffff"
-separator = "#9a8a62ff"
-tag_fg = "#d79921ff"
-tag_bg = "#282828ff"
-tag_focused_fg = "#1d2021ff"
-tag_focused_bg = "#689d68ff"
-tag_urgent_fg = "#282828ff"
-tag_urgent_bg = "#cc241dff"
-tag_inactive_fg = "#d79921ff"
-tag_inactive_bg = "#282828ff"
-
-# The font and various sizes
-font = "monospace 10"
-height = 24
-margin_top = 0
-margin_bottom = 0
-margin_left = 0
-margin_right = 0
-separator_width = 2.0
-tags_r = 0.0
-tags_padding = 25.0
-tags_margin = 0.0
-blocks_r = 0.0
-blocks_overlap = 0.0
-
-# Misc
-position = "top" # either "top" or "bottom"
-layer = "top" # one of "top", "overlay", "bottom" or "background"
-hide_inactive_tags = true
-invert_touchpad_scrolling = true
-show_tags = true
-show_layout_name = true
-blend = true # whether tags/blocks colors should blend with bar's background
-show_mode = true
-start_hidden = false # whether the bar is initially in the 'hidden' state
-
-# WM-specific options
-[wm.river]
-max_tag = 9 # Show only the first nine tags
-
-# Per output overrides
-# [output.your-output-name]
-# right now only "enable" option is available
-# enable = false
-#
-# You can have any number of overrides
-# [output.eDP-1]
-# enable = false
-```
+Take a look at the [default config](./contrib/default_config.toml) for documentation.
 You can get your fully expanded current configuration by running `i3bar-river --print-config`.
 
 ## How progressive short mode and rounded corners work

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ max_tag = 9 # Show only the first nine tags
 # [output.eDP-1]
 # enable = false
 ```
+You can get your fully expanded current configuration by running `i3bar-river --print-config`.
 
 ## How progressive short mode and rounded corners work
 

--- a/contrib/default_config.toml
+++ b/contrib/default_config.toml
@@ -1,0 +1,67 @@
+# The status generator command.
+# Optional: with no status generator the bar will display only tags and layout name.
+# command = "your command here"
+
+# The font and various sizes
+font = "monospace 10"
+height = 24
+margin_top = 0
+margin_bottom = 0
+margin_left = 0
+margin_right = 0
+separator_width = 2.0
+tags_r = 0.0
+tags_padding = 25.0
+tags_margin = 0.0
+blocks_r = 0.0
+blocks_overlap = 0.0
+
+# Misc
+position = "top" # either "top" or "bottom"
+layer = "top" # one of "top", "overlay", "bottom" or "background"
+
+invert_touchpad_scrolling = true
+start_hidden = false # whether the bar is initially in the 'hidden' state
+
+[theme.focused]
+# Colors
+background = "#282828ff"
+color = "#ffffffff"
+separator = "#9a8a62ff"
+tag_fg = "#d79921ff"
+tag_bg = "#282828ff"
+tag_focused_fg = "#1d2021ff"
+tag_focused_bg = "#689d68ff"
+tag_urgent_fg = "#282828ff"
+tag_urgent_bg = "#cc241dff"
+tag_inactive_fg = "#d79921ff"
+tag_inactive_bg = "#282828ff"
+blend = true # whether tags/blocks colors should blend with bar's background
+
+# Tab bar settings
+hide_inactive_tags = true
+show_tags = true
+show_layout_name = true
+show_mode = true
+
+[theme.unfocused]
+# Empty by default, as it inherits all unset values from the `focused` theme.
+# You can, for example, use a darker white, to show that its unfocused:
+# color = "0xbbbbbbff"
+# tag_fg = "0xbbbbbbff"
+# tag_focused_fg = "0xbbbbbbff"
+# tag_inactive_fg = "0xbbbbbbff"
+# tag_urgent_fg = "0xbbbbbbff"
+
+# WM-specific options
+[wm.river]
+max_tag = 9 # Show only the first nine tags
+
+# Per output overrides
+# [output.your-output-name]
+# right now only "enable" option is available
+# enable = false
+#
+# You can have any number of overrides
+# [output.eDP-1]
+# enable = false

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -6,12 +6,12 @@ use wayrs_utils::shm_alloc::BufferSpec;
 use crate::blocks_cache::ComputedBlock;
 use crate::button_manager::ButtonManager;
 use crate::color::Color;
-use crate::config::Position;
+use crate::config::{Config, Palette, Position};
 use crate::i3bar_protocol;
 use crate::output::Output;
 use crate::pointer_btn::PointerBtn;
 use crate::protocol::*;
-use crate::shared_state::{SharedState, sfo};
+use crate::shared_state::SharedState;
 use crate::state::State;
 use crate::text::{self, ComputedText, RenderOptions};
 use crate::wm_info_provider::Tag;
@@ -194,44 +194,38 @@ impl Bar {
         let cairo_ctx = cairo::Context::new(&cairo_surf).expect("cairo context");
         cairo_ctx.scale(scale_f, scale_f);
 
-        if !sfo!(ss, &self.output, blend) {
+        let palette = if ss.wm_info_provider.is_output_focused(&self.output) {
+            &ss.config.theme.focused
+        } else {
+            &ss.config.theme.unfocused
+        };
+
+        if !palette.blend {
             cairo_ctx.set_operator(cairo::Operator::Source);
         }
 
         // Background
-        if sfo!(ss, &self.output, blend) {
+        if palette.blend {
             cairo_ctx.save().unwrap();
             cairo_ctx.set_operator(cairo::Operator::Source);
         }
-        sfo!(ss, &self.output, background).apply(&cairo_ctx);
+        palette.background.apply(&cairo_ctx);
         cairo_ctx.paint().unwrap();
-        if sfo!(ss, &self.output, blend) {
+        if palette.blend {
             cairo_ctx.restore().unwrap();
         }
 
         // Compute tags
-        if sfo!(ss, &self.output, show_tags) && self.tags_computed.is_empty() {
+        if palette.show_tags && self.tags_computed.is_empty() {
             for tag in &self.tags {
                 let (bg, fg) = if tag.is_urgent {
-                    (
-                        sfo!(ss, &self.output, tag_urgent_bg),
-                        sfo!(ss, &self.output, tag_urgent_fg),
-                    )
+                    (palette.tag_urgent_bg, palette.tag_urgent_fg)
                 } else if tag.is_focused {
-                    (
-                        sfo!(ss, &self.output, tag_focused_bg),
-                        sfo!(ss, &self.output, tag_focused_fg),
-                    )
+                    (palette.tag_focused_bg, palette.tag_focused_fg)
                 } else if tag.is_active {
-                    (
-                        sfo!(ss, &self.output, tag_bg),
-                        sfo!(ss, &self.output, tag_fg),
-                    )
-                } else if !sfo!(ss, &self.output, hide_inactive_tags) {
-                    (
-                        sfo!(ss, &self.output, tag_inactive_bg),
-                        sfo!(ss, &self.output, tag_inactive_fg),
-                    )
+                    (palette.tag_bg, palette.tag_fg)
+                } else if !palette.hide_inactive_tags {
+                    (palette.tag_inactive_bg, palette.tag_inactive_fg)
                 } else {
                     continue;
                 };
@@ -280,7 +274,7 @@ impl Bar {
         }
 
         // Display layout name
-        if sfo!(ss, &self.output, show_layout_name) {
+        if palette.show_layout_name {
             if let Some(layout_name) = &self.layout_name {
                 let text = self.layout_name_computed.get_or_insert_with(|| {
                     ComputedText::new(
@@ -300,7 +294,7 @@ impl Bar {
                     RenderOptions {
                         x_offset: offset_left,
                         bar_height: height_f,
-                        fg_color: sfo!(ss, &self.output, tag_inactive_fg),
+                        fg_color: palette.tag_inactive_fg,
                         bg_color: None,
                         r_left: 0.0,
                         r_right: 0.0,
@@ -312,7 +306,7 @@ impl Bar {
         }
 
         // Display mode
-        if sfo!(ss, &self.output, show_mode) {
+        if palette.show_mode {
             if let Some(mode) = &self.mode_name {
                 let text = self.mode_computed.get_or_insert_with(|| {
                     ComputedText::new(
@@ -332,8 +326,8 @@ impl Bar {
                     RenderOptions {
                         x_offset: offset_left,
                         bar_height: height_f,
-                        fg_color: sfo!(ss, &self.output, tag_urgent_fg),
-                        bg_color: Some(sfo!(ss, &self.output, tag_urgent_bg)),
+                        fg_color: palette.tag_urgent_fg,
+                        bg_color: Some(palette.tag_urgent_bg),
                         r_left: ss.config.tags_r,
                         r_right: ss.config.tags_r,
                         overlap: 0.0,
@@ -346,8 +340,8 @@ impl Bar {
         // Display the blocks
         render_blocks(
             &cairo_ctx,
-            ss,
-            &self.output,
+            &ss.config,
+            palette,
             ss.blocks_cache.get_computed(),
             &mut self.blocks_btns,
             offset_left,
@@ -421,8 +415,8 @@ impl Bar {
 #[allow(clippy::too_many_arguments)]
 fn render_blocks(
     context: &cairo::Context,
-    ss: &SharedState,
-    output: &Output,
+    config: &Config,
+    palette: &Palette,
     blocks: &[ComputedBlock],
     buttons: &mut ButtonManager<(Option<String>, Option<String>)>,
     offset_left: f64,
@@ -528,15 +522,11 @@ fn render_blocks(
                 RenderOptions {
                     x_offset: full_width - blocks_width,
                     bar_height: full_height,
-                    fg_color: block.color.unwrap_or(sfo!(ss, &output, color)),
+                    fg_color: block.color.unwrap_or(palette.color),
                     bg_color: block.background,
-                    r_left: if i == 0 { ss.config.blocks_r } else { 0.0 },
-                    r_right: if i + 1 == s_len {
-                        ss.config.blocks_r
-                    } else {
-                        0.0
-                    },
-                    overlap: ss.config.blocks_overlap,
+                    r_left: if i == 0 { config.blocks_r } else { 0.0 },
+                    r_right: if i + 1 == s_len { config.blocks_r } else { 0.0 },
+                    overlap: config.blocks_overlap,
                 },
             );
             buttons.push(
@@ -548,10 +538,10 @@ fn render_blocks(
         }
 
         let separator_block_width = series.separator_block_width as f64;
-        if series.separator && ss.config.separator_width > 0.0 {
+        if series.separator && config.separator_width > 0.0 {
             let x = full_width - blocks_width + separator_block_width * 0.5;
-            sfo!(ss, &output, separator).apply(context);
-            context.set_line_width(ss.config.separator_width);
+            palette.separator.apply(context);
+            context.set_line_width(config.separator_width);
             context.move_to(x, full_height * 0.1);
             context.line_to(x, full_height * 0.9);
             context.stroke().unwrap();

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,9 +1,9 @@
 use pangocairo::cairo::Context;
-use serde::de;
-use std::fmt;
-use std::str::FromStr;
+use serde::{Serialize, de};
+use std::{fmt, str::FromStr};
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize)]
+#[serde(into = "String")]
 pub struct Color {
     red: f64,
     green: f64,
@@ -50,6 +50,24 @@ impl FromStr for Color {
         };
 
         Ok(Self::from_rgba(r, g, b, a))
+    }
+}
+
+impl From<Color> for String {
+    fn from(value: Color) -> Self {
+        let r = (value.red * 255.0) as u64;
+        let g = (value.green * 255.0) as u64;
+        let b = (value.blue * 255.0) as u64;
+        let a = (value.alpha * 255.0) as u64;
+
+        assert!(r <= u8::MAX as u64);
+        assert!(g <= u8::MAX as u64);
+        assert!(b <= u8::MAX as u64);
+        assert!(a <= u8::MAX as u64);
+
+        let hex: u64 = (r << 24) | (g << 16) | (b << 8) | a;
+
+        format!("#{hex:x}")
     }
 }
 

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -1,0 +1,157 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+use crate::color::Color;
+
+use super::{Font, Layer, OutputOverrides, Position, WmConfig};
+
+#[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields, default)]
+pub struct OldConfig {
+    pub command: Option<String>,
+
+    // font and size
+    pub font: Font,
+    pub height: u32,
+    pub margin_top: i32,
+    pub margin_bottom: i32,
+    pub margin_left: i32,
+    pub margin_right: i32,
+    pub separator_width: f64,
+    pub tags_r: f64,
+    pub tags_padding: f64,
+    pub tags_margin: f64,
+    pub blocks_r: f64,
+    pub blocks_overlap: f64,
+
+    // misc
+    pub position: Position,
+    pub layer: Layer,
+    pub invert_touchpad_scrolling: bool,
+    pub start_hidden: bool,
+
+    // The toplevel palette
+    // colors
+    pub background: Color,
+    pub color: Color,
+    pub separator: Color,
+    pub tag_fg: Color,
+    pub tag_bg: Color,
+    pub tag_focused_fg: Color,
+    pub tag_focused_bg: Color,
+    pub tag_urgent_fg: Color,
+    pub tag_urgent_bg: Color,
+    pub tag_inactive_fg: Color,
+    pub tag_inactive_bg: Color,
+
+    // Additional shown stuff
+    pub hide_inactive_tags: bool,
+    pub show_tags: bool,
+    pub show_layout_name: bool,
+    pub blend: bool,
+    pub show_mode: bool,
+
+    // wm-specific
+    pub wm: WmConfig,
+
+    // overrides
+    pub output: HashMap<String, OutputOverrides>,
+}
+
+impl From<super::Config> for OldConfig {
+    fn from(base: super::Config) -> Self {
+        Self {
+            command: base.command,
+            font: base.font,
+            margin_top: base.margin_top,
+            height: base.height,
+            margin_bottom: base.margin_bottom,
+            margin_left: base.margin_left,
+            margin_right: base.margin_right,
+            separator_width: base.separator_width,
+            tags_r: base.tags_r,
+            tags_padding: base.tags_padding,
+            tags_margin: base.tags_margin,
+            blocks_r: base.blocks_r,
+            blocks_overlap: base.blocks_overlap,
+            position: base.position,
+            layer: base.layer,
+            invert_touchpad_scrolling: base.invert_touchpad_scrolling,
+            start_hidden: base.start_hidden,
+            background: base.theme.focused.background,
+            color: base.theme.focused.color,
+            separator: base.theme.focused.separator,
+            tag_fg: base.theme.focused.tag_fg,
+            tag_bg: base.theme.focused.tag_bg,
+            tag_focused_fg: base.theme.focused.tag_focused_fg,
+            tag_focused_bg: base.theme.focused.tag_focused_bg,
+            tag_urgent_fg: base.theme.focused.tag_urgent_fg,
+            tag_urgent_bg: base.theme.focused.tag_urgent_bg,
+            tag_inactive_fg: base.theme.focused.tag_inactive_fg,
+            tag_inactive_bg: base.theme.focused.tag_inactive_bg,
+            hide_inactive_tags: base.theme.focused.hide_inactive_tags,
+            show_tags: base.theme.focused.show_tags,
+            show_layout_name: base.theme.focused.show_layout_name,
+            blend: base.theme.focused.blend,
+            show_mode: base.theme.focused.show_mode,
+            wm: base.wm,
+            output: base.output,
+        }
+    }
+}
+
+impl From<OldConfig> for super::Config {
+    fn from(base: OldConfig) -> Self {
+        let focused = super::Palette {
+            background: base.background,
+            color: base.color,
+            separator: base.separator,
+            tag_fg: base.tag_fg,
+            tag_bg: base.tag_bg,
+            tag_focused_fg: base.tag_focused_fg,
+            tag_focused_bg: base.tag_focused_bg,
+            tag_urgent_fg: base.tag_urgent_fg,
+            tag_urgent_bg: base.tag_urgent_bg,
+            tag_inactive_fg: base.tag_inactive_fg,
+            tag_inactive_bg: base.tag_inactive_bg,
+            hide_inactive_tags: base.hide_inactive_tags,
+            show_tags: base.show_tags,
+            show_layout_name: base.show_layout_name,
+            blend: base.blend,
+            show_mode: base.show_mode,
+        };
+
+        Self {
+            command: base.command,
+            theme: super::theme::Theme {
+                focused,
+                unfocused: focused,
+            },
+            font: base.font,
+            height: base.height,
+            margin_top: base.margin_top,
+            margin_bottom: base.margin_bottom,
+            margin_left: base.margin_left,
+            margin_right: base.margin_right,
+            separator_width: base.separator_width,
+            tags_r: base.tags_r,
+            tags_padding: base.tags_padding,
+            tags_margin: base.tags_margin,
+            blocks_r: base.blocks_r,
+            blocks_overlap: base.blocks_overlap,
+            position: base.position,
+            layer: base.layer,
+            invert_touchpad_scrolling: base.invert_touchpad_scrolling,
+            start_hidden: base.start_hidden,
+            wm: base.wm,
+            output: base.output,
+        }
+    }
+}
+
+impl Default for OldConfig {
+    fn default() -> Self {
+        Self::from(super::Config::default())
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,8 +1,9 @@
-use crate::color::Color;
-use crate::config::theme::Theme;
 use crate::protocol::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
+use crate::{color::Color, config::theme::Theme};
 
 use anyhow::{Context, Result};
+use migrations::OldConfig;
+use pangocairo::glib::g_warning;
 use pangocairo::pango::FontDescription;
 use serde::{Deserialize, Serialize, de};
 
@@ -146,7 +147,21 @@ impl Config {
         Ok(match path {
             Some(config_path) => {
                 let config = read_to_string(config_path).context("Failed to read configuration")?;
-                toml::from_str(&config).context("Failed to deserialize configuration")?
+                match toml::from_str(&config) {
+                    Ok(me) => me,
+                    Err(err) => {
+                        // This config could still be valid, if it is the old one.
+                        if let Ok(old) = toml::from_str(&config) {
+                            g_warning!(
+                                "i3bar-river",
+                                "Loading old config. Use `i3bar-river --print-config`, to see the new config."
+                            );
+                            <Self as From<OldConfig>>::from(old)
+                        } else {
+                            return Err(err).context("Failed to decode configuration");
+                        }
+                    }
+                }
             }
             None => {
                 eprintln!("Could not find the configuration path");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -4,7 +4,7 @@ use crate::protocol::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 
 use anyhow::{Context, Result};
 use pangocairo::pango::FontDescription;
-use serde::{Deserialize, de};
+use serde::{Deserialize, Serialize, de};
 
 use std::collections::HashMap;
 use std::fs::read_to_string;
@@ -12,9 +12,10 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use std::{env, fmt};
 
+mod migrations;
 mod theme;
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Serialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct Config {
     pub command: Option<String>,
@@ -48,7 +49,7 @@ pub struct Config {
     pub output: HashMap<String, OutputOverrides>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct Palette {
     // colors
     pub background: Color,
@@ -176,7 +177,7 @@ fn config_path() -> Option<PathBuf> {
     path.exists().then_some(path)
 }
 
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Position {
     Top,
@@ -192,7 +193,7 @@ impl From<Position> for zwlr_layer_surface_v1::Anchor {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Layer {
     Background,
@@ -212,28 +213,35 @@ impl From<Layer> for zwlr_layer_shell_v1::Layer {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct WmConfig {
     pub river: RiverConfig,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct RiverConfig {
     pub max_tag: u8,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct OutputOverrides {
     #[serde(default)]
     enable: Option<bool>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Clone)]
+#[serde(into = "String")]
 pub struct Font(pub FontDescription);
 
 impl Font {
     pub fn new(desc: &str) -> Self {
         Self(FontDescription::from_string(desc))
+    }
+}
+
+impl From<Font> for String {
+    fn from(value: Font) -> Self {
+        value.to_string()
     }
 }
 

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,0 +1,109 @@
+use serde::Deserialize;
+
+use crate::color::Color;
+
+use super::Palette;
+
+mod source {
+    use serde::Deserialize;
+
+    use crate::{color::Color, config::Palette};
+
+    #[derive(Deserialize, Debug, Default, Clone, Copy)]
+    #[serde(deny_unknown_fields, default)]
+    pub struct MaybePalette {
+        // colors
+        pub background: Option<Color>,
+        pub color: Option<Color>,
+        pub separator: Option<Color>,
+        pub tag_fg: Option<Color>,
+        pub tag_bg: Option<Color>,
+        pub tag_focused_fg: Option<Color>,
+        pub tag_focused_bg: Option<Color>,
+        pub tag_urgent_fg: Option<Color>,
+        pub tag_urgent_bg: Option<Color>,
+        pub tag_inactive_fg: Option<Color>,
+        pub tag_inactive_bg: Option<Color>,
+
+        // Additional shown stuff
+        pub hide_inactive_tags: Option<bool>,
+        pub show_tags: Option<bool>,
+        pub show_layout_name: Option<bool>,
+        pub blend: Option<bool>,
+        pub show_mode: Option<bool>,
+    }
+
+    #[derive(Deserialize, Default)]
+    #[serde(deny_unknown_fields, default)]
+    pub(super) struct Theme {
+        pub(super) palette: MaybePalette,
+        pub(super) unfocused_palette: MaybePalette,
+    }
+
+    impl MaybePalette {
+        pub(super) fn to_palette_with(self, p: Palette) -> Palette {
+            Palette {
+                background: self.background.unwrap_or(p.background),
+                color: self.color.unwrap_or(p.color),
+                separator: self.separator.unwrap_or(p.separator),
+                tag_fg: self.tag_fg.unwrap_or(p.tag_fg),
+                tag_bg: self.tag_bg.unwrap_or(p.tag_bg),
+                tag_focused_fg: self.tag_focused_fg.unwrap_or(p.tag_focused_fg),
+                tag_focused_bg: self.tag_focused_bg.unwrap_or(p.tag_focused_bg),
+                tag_urgent_fg: self.tag_urgent_fg.unwrap_or(p.tag_urgent_fg),
+                tag_urgent_bg: self.tag_urgent_bg.unwrap_or(p.tag_urgent_bg),
+                tag_inactive_fg: self.tag_inactive_fg.unwrap_or(p.tag_inactive_fg),
+                tag_inactive_bg: self.tag_inactive_bg.unwrap_or(p.tag_inactive_bg),
+
+                hide_inactive_tags: self.hide_inactive_tags.unwrap_or(p.hide_inactive_tags),
+                show_tags: self.show_tags.unwrap_or(p.show_tags),
+                show_layout_name: self.show_layout_name.unwrap_or(p.show_layout_name),
+                blend: self.blend.unwrap_or(p.blend),
+                show_mode: self.show_mode.unwrap_or(p.show_mode),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Theme {
+    pub palette: Palette,
+    pub unfocused_output: Palette, // inherits from `palette`
+}
+impl<'de> Deserialize<'de> for Theme {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let src = source::Theme::deserialize(deserializer)?;
+
+        Ok(Theme {
+            palette: src.palette.to_palette_with(Palette::default()),
+            unfocused_output: src
+                .unfocused_palette
+                .to_palette_with(src.palette.to_palette_with(unfocused_palette())),
+        })
+    }
+}
+
+fn unfocused_palette() -> Palette {
+    Palette {
+        // Use a darker white, to show that its unfocused
+        tag_fg: Color::from_rgba_hex(0xbbbbbbbb),
+        tag_focused_fg: Color::from_rgba_hex(0xbbbbbbbb),
+        tag_inactive_fg: Color::from_rgba_hex(0xbbbbbbbb),
+        tag_urgent_fg: Color::from_rgba_hex(0xbbbbbbbb),
+        color: Color::from_rgba_hex(0xbbbbbbbb),
+
+        ..Palette::default()
+    }
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self {
+            palette: Palette::default(),
+            unfocused_output: unfocused_palette(),
+        }
+    }
+}

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use super::Palette;
 
@@ -65,45 +65,19 @@ mod source {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Default, Serialize)]
+#[serde(from = "source::Theme")]
 pub struct Theme {
     pub focused: Palette,
     pub unfocused: Palette, // inherits from `focused`
 }
-impl<'de> Deserialize<'de> for Theme {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let src = source::Theme::deserialize(deserializer)?;
 
-        Ok(Theme {
-            palette: src.palette.to_palette_with(Palette::default()),
-            unfocused_output: src
-                .unfocused_palette
-                .to_palette_with(src.palette.to_palette_with(unfocused_palette())),
-        })
-    }
-}
-
-fn unfocused_palette() -> Palette {
-    Palette {
-        // Use a darker white, to show that its unfocused
-        tag_fg: Color::from_rgba_hex(0xbbbbbbbb),
-        tag_focused_fg: Color::from_rgba_hex(0xbbbbbbbb),
-        tag_inactive_fg: Color::from_rgba_hex(0xbbbbbbbb),
-        tag_urgent_fg: Color::from_rgba_hex(0xbbbbbbbb),
-        color: Color::from_rgba_hex(0xbbbbbbbb),
-
-        ..Palette::default()
-    }
-}
-
-impl Default for Theme {
-    fn default() -> Self {
-        Self {
-            palette: Palette::default(),
-            unfocused_output: unfocused_palette(),
+impl From<source::Theme> for Theme {
+    fn from(src: source::Theme) -> Self {
+        let focused = src.focused.to_palette_with(Palette::default());
+        Theme {
+            focused,
+            unfocused: src.unfocused.to_palette_with(focused),
         }
     }
 }

--- a/src/config/theme.rs
+++ b/src/config/theme.rs
@@ -1,7 +1,5 @@
 use serde::Deserialize;
 
-use crate::color::Color;
-
 use super::Palette;
 
 mod source {
@@ -36,30 +34,32 @@ mod source {
     #[derive(Deserialize, Default)]
     #[serde(deny_unknown_fields, default)]
     pub(super) struct Theme {
-        pub(super) palette: MaybePalette,
-        pub(super) unfocused_palette: MaybePalette,
+        pub(super) focused: MaybePalette,
+        pub(super) unfocused: MaybePalette,
     }
 
     impl MaybePalette {
-        pub(super) fn to_palette_with(self, p: Palette) -> Palette {
+        pub(super) fn to_palette_with(self, fallback: Palette) -> Palette {
             Palette {
-                background: self.background.unwrap_or(p.background),
-                color: self.color.unwrap_or(p.color),
-                separator: self.separator.unwrap_or(p.separator),
-                tag_fg: self.tag_fg.unwrap_or(p.tag_fg),
-                tag_bg: self.tag_bg.unwrap_or(p.tag_bg),
-                tag_focused_fg: self.tag_focused_fg.unwrap_or(p.tag_focused_fg),
-                tag_focused_bg: self.tag_focused_bg.unwrap_or(p.tag_focused_bg),
-                tag_urgent_fg: self.tag_urgent_fg.unwrap_or(p.tag_urgent_fg),
-                tag_urgent_bg: self.tag_urgent_bg.unwrap_or(p.tag_urgent_bg),
-                tag_inactive_fg: self.tag_inactive_fg.unwrap_or(p.tag_inactive_fg),
-                tag_inactive_bg: self.tag_inactive_bg.unwrap_or(p.tag_inactive_bg),
+                background: self.background.unwrap_or(fallback.background),
+                color: self.color.unwrap_or(fallback.color),
+                separator: self.separator.unwrap_or(fallback.separator),
+                tag_fg: self.tag_fg.unwrap_or(fallback.tag_fg),
+                tag_bg: self.tag_bg.unwrap_or(fallback.tag_bg),
+                tag_focused_fg: self.tag_focused_fg.unwrap_or(fallback.tag_focused_fg),
+                tag_focused_bg: self.tag_focused_bg.unwrap_or(fallback.tag_focused_bg),
+                tag_urgent_fg: self.tag_urgent_fg.unwrap_or(fallback.tag_urgent_fg),
+                tag_urgent_bg: self.tag_urgent_bg.unwrap_or(fallback.tag_urgent_bg),
+                tag_inactive_fg: self.tag_inactive_fg.unwrap_or(fallback.tag_inactive_fg),
+                tag_inactive_bg: self.tag_inactive_bg.unwrap_or(fallback.tag_inactive_bg),
 
-                hide_inactive_tags: self.hide_inactive_tags.unwrap_or(p.hide_inactive_tags),
-                show_tags: self.show_tags.unwrap_or(p.show_tags),
-                show_layout_name: self.show_layout_name.unwrap_or(p.show_layout_name),
-                blend: self.blend.unwrap_or(p.blend),
-                show_mode: self.show_mode.unwrap_or(p.show_mode),
+                hide_inactive_tags: self
+                    .hide_inactive_tags
+                    .unwrap_or(fallback.hide_inactive_tags),
+                show_tags: self.show_tags.unwrap_or(fallback.show_tags),
+                show_layout_name: self.show_layout_name.unwrap_or(fallback.show_layout_name),
+                blend: self.blend.unwrap_or(fallback.blend),
+                show_mode: self.show_mode.unwrap_or(fallback.show_mode),
             }
         }
     }
@@ -67,8 +67,8 @@ mod source {
 
 #[derive(Debug)]
 pub struct Theme {
-    pub palette: Palette,
-    pub unfocused_output: Palette, // inherits from `palette`
+    pub focused: Palette,
+    pub unfocused: Palette, // inherits from `focused`
 }
 impl<'de> Deserialize<'de> for Theme {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ use std::io::{self, ErrorKind, Read};
 use std::os::fd::AsRawFd;
 use std::path::PathBuf;
 
+use anyhow::Context;
 use clap::Parser;
+use config::Config;
 use signal_hook::consts::*;
 use wayrs_client::{Connection, IoMode};
 
@@ -35,10 +37,25 @@ struct Cli {
     /// The path to a config file.
     #[arg(short, long, value_name = "FILE")]
     config: Option<PathBuf>,
+
+    /// Print the parsed config (i.e., your specified values supplemented with the defaults)
+    #[arg(short, long)]
+    print_config: bool,
 }
 
 fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
+
+    if args.print_config {
+        let config = Config::new(args.config.as_deref()).context("Failed to read config file")?;
+
+        println!(
+            "{}",
+            toml::to_string_pretty(&config).expect("Should always work")
+        );
+
+        return Ok(());
+    }
 
     let (mut sig_read, sig_write) = io::pipe()?;
     signal_hook::low_level::pipe::register(SIGUSR1, sig_write)?;

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -37,3 +37,18 @@ impl SharedState {
         self.downcast_provider()
     }
 }
+
+/// “Select for output”
+///
+/// This avoids verbose code, when deciding which theme to use.
+macro_rules! sfo {
+    ($self:expr, $output:expr, $what:ident) => {
+        if $self.wm_info_provider.is_output_focused($output) {
+            $self.config.theme.palette.$what
+        } else {
+            $self.config.theme.unfocused_output.$what
+        }
+    };
+}
+
+pub(crate) use sfo;

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -37,18 +37,3 @@ impl SharedState {
         self.downcast_provider()
     }
 }
-
-/// “Select for output”
-///
-/// This avoids verbose code, when deciding which theme to use.
-macro_rules! sfo {
-    ($self:expr, $output:expr, $what:ident) => {
-        if $self.wm_info_provider.is_output_focused($output) {
-            $self.config.theme.palette.$what
-        } else {
-            $self.config.theme.unfocused_output.$what
-        }
-    };
-}
-
-pub(crate) use sfo;

--- a/src/state.rs
+++ b/src/state.rs
@@ -112,6 +112,9 @@ impl State {
 
         if let Err(e) = error {
             this.set_error(conn, "init", e.to_string());
+
+            // Show the error with anyhow's “Caused by” attribute.
+            eprintln!("Error on init: {:?}", e);
         }
 
         this

--- a/src/state.rs
+++ b/src/state.rs
@@ -217,6 +217,15 @@ impl State {
         });
     }
 
+    /// The focused output was updated.
+    ///
+    /// Using this instead of [`Self::tags_updated`] avoids redrawing the tags.
+    pub fn output_focus_updated(&mut self, conn: &mut Connection<Self>, output: WlOutput) {
+        self.for_each_bar(Some(output), |bar, ss| {
+            bar.frame(conn, ss);
+        });
+    }
+
     pub fn layout_name_updated(&mut self, conn: &mut Connection<Self>, output: Option<WlOutput>) {
         self.for_each_bar(output, |bar, ss| {
             bar.set_layout_name(ss.wm_info_provider.get_layout_name(&bar.output));

--- a/src/wm_info_provider.rs
+++ b/src/wm_info_provider.rs
@@ -43,6 +43,13 @@ pub trait WmInfoProvider: Any {
         None
     }
 
+    /// Whether an output is focused.
+    ///
+    /// This is primary useful to allow the user to change the theme for unfocused outputs.
+    fn is_output_focused(&self, _out: &Output) -> bool {
+        true
+    }
+
     fn click_on_tag(
         &mut self,
         _conn: &mut Connection<State>,
@@ -77,7 +84,13 @@ pub fn bind(conn: &mut Connection<State>, config: &WmConfig) -> Box<dyn WmInfoPr
 pub struct Tag {
     pub id: u32,
     pub name: String,
+
+    /// The tag is shown to the user (“focused”).
     pub is_focused: bool,
+
+    /// The tag contains views.
     pub is_active: bool,
+
+    /// The tag contains views marked as “urgent”.
     pub is_urgent: bool,
 }

--- a/src/wm_info_provider/river.rs
+++ b/src/wm_info_provider/river.rs
@@ -211,7 +211,9 @@ fn seat_status_cb(ctx: EventCtx<State, ZriverSeatStatusV1>) {
                 return;
             };
             status.is_focused = true;
-            ctx.state.tags_updated(ctx.conn, None);
+
+            let output = status.output;
+            ctx.state.output_focus_updated(ctx.conn, output);
         }
         zriver_seat_status_v1::Event::UnfocusedOutput(output) => {
             let river = ctx.state.shared_state.get_river().unwrap();
@@ -223,7 +225,9 @@ fn seat_status_cb(ctx: EventCtx<State, ZriverSeatStatusV1>) {
                 return;
             };
             status.is_focused = false;
-            ctx.state.tags_updated(ctx.conn, None);
+
+            let output = status.output;
+            ctx.state.output_focus_updated(ctx.conn, output);
         }
         _ => {}
     }

--- a/src/wm_info_provider/river.rs
+++ b/src/wm_info_provider/river.rs
@@ -213,7 +213,7 @@ fn seat_status_cb(ctx: EventCtx<State, ZriverSeatStatusV1>) {
             status.is_focused = true;
 
             let output = status.output;
-            ctx.state.output_focus_updated(ctx.conn, output);
+            ctx.state.tags_updated(ctx.conn, Some(output));
         }
         zriver_seat_status_v1::Event::UnfocusedOutput(output) => {
             let river = ctx.state.shared_state.get_river().unwrap();
@@ -227,7 +227,7 @@ fn seat_status_cb(ctx: EventCtx<State, ZriverSeatStatusV1>) {
             status.is_focused = false;
 
             let output = status.output;
-            ctx.state.output_focus_updated(ctx.conn, output);
+            ctx.state.tags_updated(ctx.conn, Some(output));
         }
         _ => {}
     }


### PR DESCRIPTION
I use multiple outputs, and as such often need to remember which output is currently focused.

Fortunately, river tells us which output is currently in focus.
Therefore, we can track this in river's info provider, and then use this value to decide which theme to use when drawing the bar.

For users that do not need or want this extra differentiation, setting the `[theme.palette]` values, will result in the previous behaviour as the `[theme.unfocused_palette]` will inherit them if not set.

By default, that is with `[theme.palette]` unset, we will use a darker white for the `unfocused_palette`'s foreground, to signify that this output is unfocused.

I am not familiar enough with niri or hyprland to know if they can support something like this too.
As such, both of their information providers do not override the default `is_output_focused` method.

In the future moving even more values to the themes might be a viable approach (i.e., the font), but with the current values most workflows should be possible (e.g., hiding inactive tags on the unfocused output, whilst showing them on the focused one or simply setting darker colours).