### PR TITLE
Support disabling WM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,11 +16,17 @@ serde_json = "1"
 serde = { version = "1", features = ["derive"] }
 signal-hook = { version = "0.3", default-features = false }
 toml = { version = "0.8", default-features = false, features = ["parse"] }
-wayrs-client = "1.0" 
+wayrs-client = "1.0"
 wayrs-protocols = { version = "0.14", features = ["wlr-layer-shell-unstable-v1", "viewporter", "fractional-scale-v1"] }
 wayrs-utils = { version = "0.17", features = ["cursor", "shm_alloc", "seats"] }
 clap = { version = "4.3", default-features = false, features = ["derive", "std", "help", "usage"] }
 libc = "0.2"
+
+[features]
+default = ["river", "niri", "hyprland"]
+river = []
+niri = []
+hyprland = []
 
 [profile.release]
 lto = "fat"

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -22,14 +22,17 @@ impl SharedState {
         <dyn Any>::downcast_mut(self.wm_info_provider.as_mut())
     }
 
+    #[cfg(feature = "river")]
     pub fn get_river(&mut self) -> Option<&mut wm_info_provider::RiverInfoProvider> {
         self.downcast_provider()
     }
 
+    #[cfg(feature = "hyprland")]
     pub fn get_hyprland(&mut self) -> Option<&mut wm_info_provider::HyprlandInfoProvider> {
         self.downcast_provider()
     }
 
+    #[cfg(feature = "niri")]
     pub fn get_niri(&mut self) -> Option<&mut wm_info_provider::NiriInfoProvider> {
         self.downcast_provider()
     }

--- a/src/wm_info_provider.rs
+++ b/src/wm_info_provider.rs
@@ -12,13 +12,19 @@ use crate::state::State;
 mod dummy;
 pub use dummy::*;
 
+#[cfg(feature = "river")]
 mod river;
+#[cfg(feature = "river")]
 pub use river::*;
 
+#[cfg(feature = "hyprland")]
 mod hyprland;
+#[cfg(feature = "hyprland")]
 pub use hyprland::*;
 
+#[cfg(feature = "niri")]
 mod niri;
+#[cfg(feature = "niri")]
 pub use niri::*;
 
 pub trait WmInfoProvider: Any {
@@ -49,14 +55,17 @@ pub trait WmInfoProvider: Any {
 }
 
 pub fn bind(conn: &mut Connection<State>, config: &WmConfig) -> Box<dyn WmInfoProvider> {
+    #[cfg(feature = "river")]
     if let Some(river) = RiverInfoProvider::bind(conn, config) {
         return Box::new(river);
     }
 
+    #[cfg(feature = "hyprland")]
     if let Some(hyprland) = HyprlandInfoProvider::new() {
         return Box::new(hyprland);
     }
 
+    #[cfg(feature = "niri")]
     if let Some(niri) = NiriInfoProvider::new() {
         return Box::new(niri);
     }


### PR DESCRIPTION
Most people profit from a bar that supports multiple compositors. But some (like me), depend on special features of a compositor and as such only ever use one of the supported compositors. Being able to disable support for the others, at compile time, allows them to remove dead code from their system.