### PR TITLE
feat: nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,23 @@
 {
   "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1751984180,
@@ -16,9 +34,60 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1752288212,
+        "narHash": "sha256-f2PMqtf61mWAM11QoIfGv3hjD2AsJrij4FCzftepuaE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "678296525a4cce249c608749b171d0b2ceb8b2ff",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -12,19 +12,15 @@
       overlays = [ (import rust-overlay) ];
       pkgs = import nixpkgs { inherit system overlays; };
       cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
-    in {
-      packages.default = pkgs.rustPlatform.buildRustPackage {
+      buildPackageWith = cargoFlags: suffix: pkgs.rustPlatform.buildRustPackage {
         pname = cargoToml.package.name;
-        version = cargoToml.package.version + "-hypr";
+        version = cargoToml.package.version + suffix;
 
         src = ./.;
 
         cargoLock.lockFile = ./Cargo.lock;
 
-        cargoBuildFlags = [
-          "--no-default-features"
-          "--features=hyprland"
-        ];
+        cargoBuildFlags = cargoFlags;
 
         nativeBuildInputs = [ pkgs.pkg-config ];
         buildInputs = [ pkgs.pango ];
@@ -37,6 +33,12 @@
           license = licenses.gpl3Only;
           mainProgram = "i3bar-river";
         };
+      };
+      buildForWM = wm: buildPackageWith [ "--no-default-features" ("--features="+wm) ] ("-" + wm);
+      wms = [ "river" "niri" "hyprland" ];
+    in {
+      packages = (builtins.listToAttrs (map (wm: { name = wm; value = buildForWM wm; }) wms)) // {
+        default = buildPackageWith [] "";
       };
 
       devShells.default = with pkgs; mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -3,22 +3,23 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    flake-utils.url  = "github:numtide/flake-utils";
   };
 
-  outputs =
-    { self, nixpkgs }:
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }: flake-utils.lib.eachDefaultSystem (system:
     let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-
-    in
-    {
-      packages.${system}.default = pkgs.rustPlatform.buildRustPackage {
-        pname = "i3bar-river";
-        version = "1.1.0-hypr";
+      overlays = [ (import rust-overlay) ];
+      pkgs = import nixpkgs { inherit system overlays; };
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+    in {
+      packages.default = pkgs.rustPlatform.buildRustPackage {
+        pname = cargoToml.package.name;
+        version = cargoToml.package.version + "-hypr";
 
         src = ./.;
-        cargoHash = "sha256-8sub8cXC/1iDY6v/9opO4FiLAo9CFrGJSDPNQydGvhQ=";
+
+        cargoLock.lockFile = ./Cargo.lock;
 
         cargoBuildFlags = [
           "--no-default-features"
@@ -31,12 +32,22 @@
         cargoRelease = true;
 
         meta = with pkgs.lib; {
-          description = "Fork of i3bar-river Hyprland-only";
-          homepage = "https://github.com/EdwinLeeford/i3bar-river";
+          description = cargoToml.package.description;
+          homepage = cargoToml.package.repository;
           license = licenses.gpl3Only;
           mainProgram = "i3bar-river";
         };
-
       };
-    };
+
+      devShells.default = with pkgs; mkShell {
+        nativeBuildInputs = [ pkgs.pkg-config ];
+        buildInputs = [
+          pango
+          (rust-bin.beta.latest.default.override {
+            extensions = [ "rust-src" ];
+          })
+        ];
+      };
+    }
+  );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  description = "Hyprland-only build of i3bar-river";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+
+    in
+    {
+      packages.${system}.default = pkgs.rustPlatform.buildRustPackage {
+        pname = "i3bar-river";
+        version = "1.1.0-hypr";
+
+        src = ./.;
+        cargoHash = "sha256-8sub8cXC/1iDY6v/9opO4FiLAo9CFrGJSDPNQydGvhQ=";
+
+        cargoBuildFlags = [
+          "--no-default-features"
+          "--features=hyprland"
+        ];
+
+        nativeBuildInputs = [ pkgs.pkg-config ];
+        buildInputs = [ pkgs.pango ];
+
+        cargoRelease = true;
+
+        meta = with pkgs.lib; {
+          description = "Fork of i3bar-river Hyprland-only";
+          homepage = "https://github.com/EdwinLeeford/i3bar-river";
+          license = licenses.gpl3Only;
+          mainProgram = "i3bar-river";
+        };
+
+      };
+    };
+}


### PR DESCRIPTION
This PR adds a nix flake with a devshell and multiple nix packages. There is one package including support for all WMs, and one package per WM which only supports that WM. I have also kept maintainability in mind, so there should be very few changes of the flake.nix required in the future (in which case feel free to ping me to take care of that).

Note This PR is based on @EdwinLeeford's work on a hyprland specific flake (See [EdwinLeeford/i3bar-river@hyprland-flake](https://github.com/EdwinLeeford/i3bar-river/tree/hyprland-flake))