### PR TITLE
feat(hyprland): option to hide empty workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ start_hidden = false # whether the bar is initially in the 'hidden' state
 [wm.river]
 max_tag = 9 # Show only the first nine tags
 
+[wm.hyprland]
+show_empty = true # whether to show empty workspaces
+
 # Per output overrides
 # [output.your-output-name]
 # right now only "enable" option is available

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ start_hidden = false # whether the bar is initially in the 'hidden' state
 max_tag = 9 # Show only the first nine tags
 
 [wm.hyprland]
-empty_is_active = true # whether to consider empty workspaces as active
+always_show_persistent = true # whether to always show persistent workspaces, even if they are empty
 
 # Per output overrides
 # [output.your-output-name]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ start_hidden = false # whether the bar is initially in the 'hidden' state
 max_tag = 9 # Show only the first nine tags
 
 [wm.hyprland]
-show_empty = true # whether to consider empty workspaces as active
+empty_is_active = true # whether to consider empty workspaces as active
 
 # Per output overrides
 # [output.your-output-name]

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ start_hidden = false # whether the bar is initially in the 'hidden' state
 max_tag = 9 # Show only the first nine tags
 
 [wm.hyprland]
-show_empty = true # whether to show empty workspaces
+show_empty = true # whether to consider empty workspaces as active
 
 # Per output overrides
 # [output.your-output-name]

--- a/src/config.rs
+++ b/src/config.rs
@@ -209,19 +209,21 @@ pub struct RiverConfig {
 
 impl Default for RiverConfig {
     fn default() -> Self {
-        Self { max_tag: 9, }
+        Self { max_tag: 9 }
     }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct HyprlandConfig {
-    pub show_empty: bool,
+    pub empty_is_active: bool,
 }
 
 impl Default for HyprlandConfig {
     fn default() -> Self {
-        Self { show_empty: true, }
+        Self {
+            empty_is_active: true,
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,9 +96,7 @@ impl Default for Config {
             show_mode: true,
             start_hidden: false,
 
-            wm: WmConfig {
-                river: RiverConfig { max_tag: 9 },
-            },
+            wm: WmConfig::default(),
 
             output: HashMap::new(),
         }
@@ -188,13 +186,43 @@ impl From<Layer> for zwlr_layer_shell_v1::Layer {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct WmConfig {
     pub river: RiverConfig,
+    pub hyprland: HyprlandConfig,
+}
+
+impl Default for WmConfig {
+    fn default() -> Self {
+        Self {
+            river: Default::default(),
+            hyprland: Default::default(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, default)]
 pub struct RiverConfig {
     pub max_tag: u8,
+}
+
+impl Default for RiverConfig {
+    fn default() -> Self {
+        Self { max_tag: 9, }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct HyprlandConfig {
+    pub show_empty: bool,
+}
+
+impl Default for HyprlandConfig {
+    fn default() -> Self {
+        Self { show_empty: true, }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -216,13 +216,13 @@ impl Default for RiverConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields, default)]
 pub struct HyprlandConfig {
-    pub empty_is_active: bool,
+    pub always_show_persistent: bool,
 }
 
 impl Default for HyprlandConfig {
     fn default() -> Self {
         Self {
-            empty_is_active: true,
+            always_show_persistent: true,
         }
     }
 }

--- a/src/wm_info_provider.rs
+++ b/src/wm_info_provider.rs
@@ -61,7 +61,7 @@ pub fn bind(conn: &mut Connection<State>, config: &WmConfig) -> Box<dyn WmInfoPr
     }
 
     #[cfg(feature = "hyprland")]
-    if let Some(hyprland) = HyprlandInfoProvider::new() {
+    if let Some(hyprland) = HyprlandInfoProvider::new(config) {
         return Box::new(hyprland);
     }
 

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -125,11 +125,10 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                         let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
                             io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
                         })?;
-                        hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         hyprland.active_name = active_ws.to_owned();
                         updated = true;
                     },
-                    "createworkspace" | "openwindow" | "closewindow" => {
+                    "createworkspace" | "openwindow" | "closewindow" | "movewindow" => {
                         hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         updated = true;
                     }

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -118,6 +118,7 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                 match event_type {
                     "workspace" => {
                         hyprland.active_name = data.to_owned();
+                        hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         updated = true;
                     },
                     "focusedmon" => {

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -15,7 +15,7 @@ pub struct HyprlandInfoProvider {
     ipc: Ipc,
     workspaces: Vec<IpcWorkspace>,
     active_name: String,
-    show_empty: bool,
+    empty_is_active: bool,
 }
 
 impl HyprlandInfoProvider {
@@ -29,7 +29,7 @@ impl HyprlandInfoProvider {
                 .ok()?
                 .name,
             ipc,
-            show_empty: config.hyprland.show_empty,
+            empty_is_active: config.hyprland.empty_is_active,
         })
     }
 
@@ -59,7 +59,7 @@ impl WmInfoProvider for HyprlandInfoProvider {
                 id: ws.id,
                 name: ws.name.clone(),
                 is_focused: ws.name == self.active_name,
-                is_active: self.show_empty || ws.windows > 0,
+                is_active: self.empty_is_active || ws.windows > 0,
                 is_urgent: false,
             })
             .collect()
@@ -114,24 +114,24 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
     loop {
         match hyprland.ipc.next_event() {
             Ok(event) => {
-                let (event_type, data)  = event.split_once(">>").unwrap();
+                let (event_type, data) = event.split_once(">>").unwrap();
                 match event_type {
                     "workspace" => {
                         hyprland.active_name = data.to_owned();
                         updated = true;
-                    },
+                    }
                     "focusedmon" => {
                         let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
                             io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
                         })?;
                         hyprland.active_name = active_ws.to_owned();
                         updated = true;
-                    },
+                    }
                     "createworkspace" | "openwindow" | "closewindow" | "movewindow" => {
                         hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         updated = true;
-                    },
-                    _ => {},
+                    }
+                    _ => {}
                 }
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -54,12 +54,12 @@ impl WmInfoProvider for HyprlandInfoProvider {
     fn get_tags(&self, output: &Output) -> Vec<Tag> {
         self.workspaces
             .iter()
-            .filter(|ws| ws.monitor == output.name && (self.show_empty || ws.windows > 0))
+            .filter(|ws| ws.monitor == output.name)
             .map(|ws| Tag {
                 id: ws.id,
                 name: ws.name.clone(),
                 is_focused: ws.name == self.active_name,
-                is_active: true,
+                is_active: self.show_empty || ws.windows > 0,
                 is_urgent: false,
             })
             .collect()
@@ -118,7 +118,6 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                 match event_type {
                     "workspace" => {
                         hyprland.active_name = data.to_owned();
-                        hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         updated = true;
                     },
                     "focusedmon" => {
@@ -131,7 +130,7 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                     "createworkspace" | "openwindow" | "closewindow" | "movewindow" => {
                         hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         updated = true;
-                    }
+                    },
                     _ => {},
                 }
             }

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -15,7 +15,7 @@ pub struct HyprlandInfoProvider {
     ipc: Ipc,
     workspaces: Vec<IpcWorkspace>,
     active_name: String,
-    empty_is_active: bool,
+    always_show_persistent: bool,
 }
 
 impl HyprlandInfoProvider {
@@ -29,7 +29,7 @@ impl HyprlandInfoProvider {
                 .ok()?
                 .name,
             ipc,
-            empty_is_active: config.hyprland.empty_is_active,
+            always_show_persistent: config.hyprland.always_show_persistent,
         })
     }
 
@@ -59,7 +59,7 @@ impl WmInfoProvider for HyprlandInfoProvider {
                 id: ws.id,
                 name: ws.name.clone(),
                 is_focused: ws.name == self.active_name,
-                is_active: self.empty_is_active || ws.windows > 0,
+                is_active: ws.windows > 0 || (self.always_show_persistent && ws.ispersistent),
                 is_urgent: false,
             })
             .collect()
@@ -212,4 +212,5 @@ struct IpcWorkspace {
     name: String,
     monitor: String,
     windows: u32,
+    ispersistent: bool,
 }

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -15,10 +15,11 @@ pub struct HyprlandInfoProvider {
     ipc: Ipc,
     workspaces: Vec<IpcWorkspace>,
     active_name: String,
+    show_empty: bool,
 }
 
 impl HyprlandInfoProvider {
-    pub fn new() -> Option<Self> {
+    pub fn new(config: &WmConfig) -> Option<Self> {
         let his = std::env::var("HYPRLAND_INSTANCE_SIGNATURE").ok()?;
         let ipc = Ipc::new(&his)?;
         Some(Self {
@@ -28,6 +29,7 @@ impl HyprlandInfoProvider {
                 .ok()?
                 .name,
             ipc,
+            show_empty: config.hyprland.show_empty,
         })
     }
 
@@ -52,7 +54,7 @@ impl WmInfoProvider for HyprlandInfoProvider {
     fn get_tags(&self, output: &Output) -> Vec<Tag> {
         self.workspaces
             .iter()
-            .filter(|ws| ws.monitor == output.name)
+            .filter(|ws| ws.monitor == output.name && (self.show_empty || ws.windows > 0))
             .map(|ws| Tag {
                 id: ws.id,
                 name: ws.name.clone(),
@@ -112,18 +114,24 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
     loop {
         match hyprland.ipc.next_event() {
             Ok(event) => {
-                if let Some(active_ws) = event.strip_prefix("workspace>>") {
-                    hyprland.active_name = active_ws.to_owned();
-                    updated = true;
-                } else if let Some(data) = event.strip_prefix("focusedmon>>") {
-                    let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
-                        io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
-                    })?;
-                    hyprland.active_name = active_ws.to_owned();
-                    updated = true;
-                } else if event.contains("workspace>>") {
-                    hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
-                    updated = true;
+                let (event_type, data)  = event.split_once(">>").unwrap();
+                match event_type {
+                    "workspace" => {
+                        hyprland.active_name = data.to_owned();
+                        updated = true;
+                    },
+                    "focusedmon" => {
+                        let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
+                            io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
+                        })?;
+                        hyprland.active_name = active_ws.to_owned();
+                        updated = true;
+                    },
+                    "createworkspace" | "openwindow" | "closewindow" => {
+                        hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
+                        updated = true;
+                    }
+                    _ => {},
                 }
             }
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => break,
@@ -203,4 +211,5 @@ struct IpcWorkspace {
     id: u32,
     name: String,
     monitor: String,
+    windows: u32,
 }

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -125,6 +125,7 @@ fn hyprland_cb(conn: &mut Connection<State>, state: &mut State) -> io::Result<()
                         let (_monitor, active_ws) = data.split_once(',').ok_or_else(|| {
                             io::Error::new(io::ErrorKind::InvalidData, "Too few fields in data")
                         })?;
+                        hyprland.workspaces = hyprland.ipc.query_sorted_workspaces()?;
                         hyprland.active_name = active_ws.to_owned();
                         updated = true;
                     },


### PR DESCRIPTION
- `config.rs` changes are to add the `show_empty` option and fix a resulting bug where all options for all window managers had to be specified
- `hyprland.rs` changes are to implement the `show_empty` option and a small refactoring of the `get_tags` method to make the event parsing clearer (I already had to change the method anyways, so I figured I would do this while I am at it)