### PR TITLE
use i64 rather than u32 for workspace ids

### DIFF
--- a/src/bar.rs
+++ b/src/bar.rs
@@ -33,8 +33,8 @@ pub struct Bar {
     tags: Vec<Tag>,
     layout_name: Option<String>,
     mode_name: Option<String>,
-    tags_btns: ButtonManager<u32>,
-    tags_computed: Vec<(u32, ColorPair, ComputedText)>,
+    tags_btns: ButtonManager<i32>,
+    tags_computed: Vec<(i32, ColorPair, ComputedText)>,
     layout_name_computed: Option<ComputedText>,
     mode_computed: Option<ComputedText>,
 }

--- a/src/wm_info_provider.rs
+++ b/src/wm_info_provider.rs
@@ -48,7 +48,7 @@ pub trait WmInfoProvider: Any {
         _conn: &mut Connection<State>,
         _output: &Output,
         _seat: WlSeat,
-        _tag_id: Option<u32>,
+        _tag_id: Option<i32>,
         _btn: PointerBtn,
     ) {
     }
@@ -75,7 +75,7 @@ pub fn bind(conn: &mut Connection<State>, config: &WmConfig) -> Box<dyn WmInfoPr
 
 #[derive(Debug)]
 pub struct Tag {
-    pub id: u32,
+    pub id: i32,
     pub name: String,
     pub is_focused: bool,
     pub is_active: bool,

--- a/src/wm_info_provider/hyprland.rs
+++ b/src/wm_info_provider/hyprland.rs
@@ -31,7 +31,7 @@ impl HyprlandInfoProvider {
         })
     }
 
-    fn set_workspace(&self, id: u32) {
+    fn set_workspace(&self, id: i32) {
         let _ = self.ipc.exec(&format!("/dispatch workspace {id}"));
     }
 }
@@ -68,7 +68,7 @@ impl WmInfoProvider for HyprlandInfoProvider {
         _: &mut Connection<State>,
         output: &Output,
         _: WlSeat,
-        tag_id: Option<u32>,
+        tag_id: Option<i32>,
         btn: PointerBtn,
     ) {
         match btn {
@@ -200,7 +200,7 @@ impl Ipc {
 
 #[derive(Debug, serde::Deserialize)]
 struct IpcWorkspace {
-    id: u32,
+    id: i32,
     name: String,
     monitor: String,
 }

--- a/src/wm_info_provider/niri.rs
+++ b/src/wm_info_provider/niri.rs
@@ -26,7 +26,7 @@ impl NiriInfoProvider {
         })
     }
 
-    fn set_workspace(&self, idx: u32) {
+    fn set_workspace(&self, idx: i32) {
         let _ = self.ipc.exec(&format!(
             r#"{{"Action":{{"FocusWorkspace":{{"reference":{{"Index":{idx}}}}}}}}}"#
         ));
@@ -78,7 +78,7 @@ impl WmInfoProvider for NiriInfoProvider {
         _: &mut Connection<State>,
         output: &Output,
         _: WlSeat,
-        tag_id: Option<u32>,
+        tag_id: Option<i32>,
         btn: PointerBtn,
     ) {
         match btn {
@@ -205,8 +205,8 @@ impl Ipc {
 
 #[derive(Debug, serde::Deserialize)]
 struct IpcWorkspace {
-    id: u32,  // Niri's internal id is monotonic, only used for comparison.
-    idx: u32, // idx is the user-facing workspace number.
+    id: i32,  // Niri's internal id is monotonic, only used for comparison.
+    idx: i32, // idx is the user-facing workspace number.
     name: Option<String>,
     output: String,
     is_focused: bool,
@@ -220,7 +220,7 @@ enum IpcEvent {
         workspaces: Vec<IpcWorkspace>,
     },
     WorkspaceActivated {
-        id: u32,
+        id: i32,
         focused: bool,
     },
     #[serde(untagged)]

--- a/src/wm_info_provider/river.rs
+++ b/src/wm_info_provider/river.rs
@@ -81,7 +81,7 @@ impl WmInfoProvider for RiverInfoProvider {
         };
         (1..=u8::min(self.max_tag, 32))
             .map(|tag| Tag {
-                id: tag as u32,
+                id: tag as i32,
                 name: tag.to_string(),
                 is_focused: status.focused_tags & (1 << (tag - 1)) != 0,
                 is_active: status.active_tags & (1 << (tag - 1)) != 0,
@@ -107,7 +107,7 @@ impl WmInfoProvider for RiverInfoProvider {
         conn: &mut Connection<State>,
         output: &Output,
         seat: WlSeat,
-        tag_id: Option<u32>,
+        tag_id: Option<i32>,
         btn: PointerBtn,
     ) {
         match btn {


### PR DESCRIPTION
Hyprland's special workspaces have negative indices which would cause i3bar-river to irrecoverably display an error.

I built this before I looked whether someone else already did this and found https://github.com/MaxVerevkin/i3bar-river/pull/47/.

I think I like not filtering out workspaces at all to be the better option because this way the special workspace is shown in front of the other workspaces but only when it's activated which I find quite intuitive; it's special afterall.

This behaviour is infinitely better than irrecoverably soft-crashing either way.

Fixes https://github.com/MaxVerevkin/i3bar-river/issues/46