### PR TITLE
fix(niri): read reply after IPC exec to avoid broken pipe error

### DIFF
--- a/src/wm_info_provider/niri.rs
+++ b/src/wm_info_provider/niri.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::collapsible_else_if)]
 
-use std::io::{self, Write};
+use std::io::{self, Read, Write};
 use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
@@ -182,7 +182,11 @@ impl Ipc {
     fn exec(&self, cmd: &str) -> io::Result<()> {
         let mut sock = UnixStream::connect(&self.sock_path)?;
         sock.write_all(cmd.as_bytes())?;
+        sock.write_all(b"\n")?;
         sock.flush()?;
+        // Read the reply to prevent niri from getting a broken pipe error.
+        let mut buf = [0u8; 4096];
+        let _ = sock.read(&mut buf);
         Ok(())
     }
 


### PR DESCRIPTION
When clicking or scrolling on workspace buttons, the bar sends an IPC command to niri but closes the socket without reading the reply. This causes niri to log a warning:

```
2026-07-18T06:26:04.201336Z  WARN niri::ipc::server: error handling IPC client: error writing reply
Caused by:
    Broken pipe (os error 32)
```

The fix:
- Append a newline to the command (niri expects newline-terminated JSON requests per the [IPC protocol](https://niri-wm.github.io/niri/niri_ipc/))
- Read the reply before closing the connection, so niri can successfully write its response