### PR TITLE
Add StatusNotifierItem tray support via rustsni

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,12 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
@@ -32,7 +38,7 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b58e62a27cd02fb3f63f82bb31fdda7e6c43141497cbe97e8816d7c914043f55"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -58,6 +64,12 @@ dependencies = [
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
@@ -88,7 +100,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -98,10 +110,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "freedesktop-icons"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95f87364ea709292a3b3f74014ce3ee78412c89807eea75a358c8e029b000994"
+dependencies = [
+ "dirs",
+ "ini_core",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tracing",
+ "xdg",
+]
 
 [[package]]
 name = "futures-channel"
@@ -143,7 +190,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -164,6 +211,17 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -193,7 +251,7 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -202,7 +260,7 @@ version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c501c495842c2b23cdacead803a5a343ca2a5d7a7ddaff14cc5f6cf22cfb92c2"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -227,7 +285,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -268,10 +326,13 @@ name = "i3bar-river"
 version = "1.1.0"
 dependencies = [
  "anyhow",
+ "cairo-rs",
  "clap",
+ "freedesktop-icons",
  "libc",
  "memchr",
  "pangocairo",
+ "rustsni",
  "serde",
  "serde_json",
  "signal-hook",
@@ -292,6 +353,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ini_core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a467a31a9f439b5262fa99c17084537bff57f24703d5a09a2b5c9657ec73a61"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +372,15 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -317,6 +396,40 @@ checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "pango"
@@ -423,6 +536,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustbus"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4054c51e241d0c6d57fab9fecda2223b7bdc7621be67f0d70568d94a6762f281"
+dependencies = [
+ "nix",
+ "rustbus_derive",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "rustbus_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dcb6a55a8a297bb62066b114624aac082ac1a330d90a0d5b336645208e29ae2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "rustsni"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667bb5a0be3c02f85ff8fb56176f30ceb256d8961620f3ab1bee57e46de83c07"
+dependencies = [
+ "rustbus",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +601,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -514,6 +670,17 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
@@ -541,6 +708,46 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "toml"
@@ -577,6 +784,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,6 +825,12 @@ name = "version-compare"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wayrs-client"
@@ -652,11 +896,35 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -665,15 +933,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -683,9 +957,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -701,9 +987,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -713,9 +1011,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -737,3 +1047,9 @@ name = "xcursor"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ef33da6b1660b4ddbfb3aef0ade110c8b8a781a3b6382fa5f2b5b040fd55f61"
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ wayrs-client = "1.0"
 wayrs-protocols = { version = "0.14", features = ["wlr-layer-shell-unstable-v1", "viewporter", "fractional-scale-v1"] }
 wayrs-utils = { version = "0.17", features = ["cursor", "shm_alloc", "seats"] }
 clap = { version = "4.3", default-features = false, features = ["derive", "std", "help", "usage"] }
+cairo-rs = { version = "0.20", default-features = false, features = ["png"] }
 libc = "0.2"
+rustsni = "0.2.2"
+freedesktop-icons = "0.4"
 
 [features]
 default = ["river", "niri", "hyprland"]

--- a/src/bar.rs
+++ b/src/bar.rs
@@ -14,6 +14,7 @@ use crate::protocol::*;
 use crate::shared_state::SharedState;
 use crate::state::State;
 use crate::text::{self, ComputedText, RenderOptions};
+use crate::tray;
 use crate::wm_info_provider::Tag;
 
 pub struct Bar {
@@ -34,6 +35,7 @@ pub struct Bar {
     layout_name: Option<String>,
     mode_name: Option<String>,
     tags_btns: ButtonManager<u32>,
+    tray_btns: ButtonManager<String>,
     tags_computed: Vec<(u32, ColorPair, ComputedText)>,
     layout_name_computed: Option<ComputedText>,
     mode_computed: Option<ComputedText>,
@@ -80,6 +82,7 @@ impl Bar {
             layout_name: None,
             mode_name: None,
             tags_btns: Default::default(),
+            tray_btns: Default::default(),
             tags_computed: Vec::new(),
             layout_name_computed: None,
             mode_computed: None,
@@ -94,6 +97,10 @@ impl Bar {
         }
         self.surface.destroy(conn);
         self.output.destroy(conn);
+    }
+
+    pub fn scale_f(&self) -> f64 {
+        self.scale120.map(|s| s as f64 / 120.0).unwrap_or(self.output.scale as f64)
     }
 
     pub fn set_tags(&mut self, tags: Vec<Tag>) {
@@ -127,6 +134,8 @@ impl Bar {
         } else if self.tags_btns.is_between(x) {
             ss.wm_info_provider
                 .click_on_tag(conn, &self.output, seat, None, button);
+        } else if let Some(tray_id) = self.tray_btns.click(x) {
+            tray::handle_click(ss, tray_id, button);
         } else if let Some((name, instance)) = self.blocks_btns.click(x) {
             if let Some(cmd) = &mut ss.status_cmd {
                 cmd.send_click_event(&i3bar_protocol::Event {
@@ -319,6 +328,26 @@ impl Bar {
             }
         }
 
+        // Display tray icons
+        let tray_width = if ss.tray_cache.is_empty() {
+            0.0
+        } else {
+            let slot = (height_f - 4.0).max(16.0);
+            let n = ss.tray_cache.len() as f64;
+            n * slot + (n - 1.0) * 4.0
+        };
+        let blocks_end = width_f - tray_width;
+        if tray_width > 0.0 {
+            tray::render(
+                &cairo_ctx,
+                ss,
+                &mut self.tray_btns,
+                blocks_end,
+                height_f,
+                scale_f,
+            );
+        }
+
         // Display the blocks
         render_blocks(
             &cairo_ctx,
@@ -326,7 +355,7 @@ impl Bar {
             ss.blocks_cache.get_computed(),
             &mut self.blocks_btns,
             offset_left,
-            width_f,
+            blocks_end,
             height_f,
         );
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,8 @@ pub struct Config {
     pub tags_margin: f64,
     pub blocks_r: f64,
     pub blocks_overlap: f64,
+    // tray menu
+    pub menu_command: Option<String>,
     // misc
     pub position: Position,
     pub layer: Layer,
@@ -59,6 +61,7 @@ impl Default for Config {
     fn default() -> Self {
         Self {
             command: None,
+            menu_command: None,
 
             // A kind of gruvbox theme
             background: Color::from_rgba_hex(0x282828ff),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod shared_state;
 mod state;
 mod status_cmd;
 mod text;
+mod tray;
 mod utils;
 mod wm_info_provider;
 
@@ -48,7 +49,14 @@ fn main() -> anyhow::Result<()> {
 
     let mut el = EventLoop::new();
     let mut state = State::new(&mut conn, &mut el, args.config.as_deref());
+
+    // Initialize tray host, drain initial discovery events, and register D-Bus fd.
+    let max_scale = state.max_bar_scale();
+    let tray_dirty = tray::init(&mut state.shared_state, max_scale, &mut el);
     conn.flush(IoMode::Blocking)?;
+    if tray_dirty {
+        state.draw_all(&mut conn);
+    }
 
     el.add_on_idle(|ctx| {
         ctx.conn.flush(IoMode::Blocking)?;

--- a/src/shared_state.rs
+++ b/src/shared_state.rs
@@ -1,4 +1,5 @@
 use std::any::Any;
+use std::collections::HashMap;
 
 use crate::{
     blocks_cache::BlocksCache,
@@ -7,7 +8,14 @@ use crate::{
     wm_info_provider::{self, WmInfoProvider},
 };
 
+use rustsni::TrayHost;
 use wayrs_utils::shm_alloc::ShmAlloc;
+
+pub struct CachedIcon {
+    pub data: Vec<u8>,
+    pub w: u32,
+    pub h: u32,
+}
 
 pub struct SharedState {
     pub shm: ShmAlloc,
@@ -15,6 +23,8 @@ pub struct SharedState {
     pub status_cmd: Option<StatusCmd>,
     pub blocks_cache: BlocksCache,
     pub wm_info_provider: Box<dyn WmInfoProvider>,
+    pub tray: Option<TrayHost>,
+    pub tray_cache: HashMap<String, CachedIcon>,
 }
 
 impl SharedState {

--- a/src/state.rs
+++ b/src/state.rs
@@ -104,6 +104,8 @@ impl State {
                 status_cmd,
                 blocks_cache: BlocksCache::default(),
                 wm_info_provider,
+                tray: None,
+                tray_cache: std::collections::HashMap::new(),
             },
 
             cursor_theme,
@@ -141,6 +143,14 @@ impl State {
         for bar in &mut self.bars {
             bar.frame(conn, &mut self.shared_state);
         }
+    }
+
+    pub fn max_bar_scale(&self) -> f64 {
+        self.bars
+            .iter()
+            .map(|b| b.scale_f())
+            .fold(0.0f64, f64::max)
+            .max(1.0)
     }
 
     pub fn status_cmd_fd(&self) -> Option<RawFd> {

--- a/src/tray.rs
+++ b/src/tray.rs
@@ -1,0 +1,397 @@
+//! Tray integration using rustsni.
+
+use std::fs::File;
+
+use pangocairo::cairo;
+
+use crate::button_manager::ButtonManager;
+use crate::event_loop::{Action, EventLoop};
+use crate::pointer_btn::PointerBtn;
+use crate::shared_state::SharedState;
+
+use rustsni::{ItemId, MenuNode, TrayEvent, TrayItem};
+
+use crate::shared_state::CachedIcon;
+
+/// Initialize the tray host and drain initial discovery events.
+///
+/// The first `poll()` may buffer items in `pending_messages` during
+/// synchronous `GetAll` waits (items responding to
+/// `StatusNotifierHostRegistered`).  This loop re-polls until no events
+/// remain, so all items are discovered before the first render.
+///
+/// Returns `true` if any items were discovered (caller should redraw).
+pub fn init(ss: &mut SharedState, max_scale: f64, el: &mut EventLoop) -> bool {
+    match rustsni::TrayHost::new() {
+        Ok(host) => ss.tray = Some(host),
+        Err(e) => {
+            eprintln!("tray init error: {e}");
+            return false;
+        }
+    }
+
+    if let Some(tray) = &ss.tray {
+        let tray_fd = tray.fd();
+        el.register_with_fd(tray_fd, |ctx| {
+            let max_scale = ctx.state.max_bar_scale();
+            while poll(&mut ctx.state.shared_state, max_scale) {
+                ctx.state.draw_all(ctx.conn);
+            }
+            Ok(Action::Keep)
+        });
+    }
+
+    let mut dirty = false;
+    while poll(ss, max_scale) {
+        dirty = true;
+    }
+    dirty
+}
+
+/// Process pending tray events. Call when the tray fd is readable.
+pub fn poll(ss: &mut SharedState, max_scale: f64) -> bool {
+    let tray = match &mut ss.tray {
+        Some(t) => t,
+        None => return false,
+    };
+    let max_h = (slot_size(ss.config.height as f64) * max_scale).ceil() as u32;
+    match tray.poll() {
+        Ok(events) => {
+            for ev in &events {
+                match ev {
+                    TrayEvent::ItemAdded(id) | TrayEvent::ItemChanged(id) => {
+                        if let Some(item) = tray.items().get(id) {
+                            if let Some((data, w, h)) = resolve_icon(item, max_h) {
+                                ss.tray_cache
+                                    .insert(item.id.0.clone(), CachedIcon { data, w, h });
+                            } else {
+                                ss.tray_cache.remove(&item.id.0);
+                            }
+                        }
+                    }
+                    TrayEvent::ItemRemoved(id) => {
+                        ss.tray_cache.remove(&id.0);
+                    }
+                    TrayEvent::MenuChanged(_) | TrayEvent::MenuActivationRequested(_) => {}
+                    TrayEvent::HostShutdown => {}
+                }
+            }
+            !events.is_empty()
+        }
+        Err(e) => {
+            eprintln!("tray poll error: {e}");
+            false
+        }
+    }
+}
+
+/// Handle a click on the tray item identified by `id`.
+pub fn handle_click(ss: &mut SharedState, id: &str, btn: PointerBtn) -> bool {
+    let tray = match &mut ss.tray {
+        Some(t) => t,
+        None => return false,
+    };
+    let id = ItemId(id.to_owned());
+    let item = tray.items().get(&id);
+    let has_menu = item.is_some_and(|i| i.has_menu());
+
+    match btn {
+        PointerBtn::Left => {
+            if item.is_some_and(|i| i.item_is_menu) && has_menu {
+                show_menu(ss, &id);
+            } else {
+                let _ = tray.activate(&id, 0, 0);
+            }
+        }
+        PointerBtn::Right => {
+            if has_menu {
+                show_menu(ss, &id);
+            } else {
+                let _ = tray.context_menu(&id, 0, 0);
+            }
+        }
+        _ => return false,
+    }
+    true
+}
+
+/// Show the context menu for a tray item using rofi -dmenu.
+/// Spawns a thread so the event loop is not blocked.
+fn show_menu(ss: &mut SharedState, id: &ItemId) {
+    let tray = match &mut ss.tray {
+        Some(t) => t,
+        None => return,
+    };
+
+    // Get the menu layout
+    let nodes = match tray.get_menu(id, 0) {
+        Ok(n) => n,
+        Err(_) => return,
+    };
+
+    if nodes.is_empty() {
+        // No DBusMenu layout — fall back to ContextMenu method
+        let _ = tray.context_menu(id, 0, 0);
+        return;
+    }
+
+    let item = match tray.items().get(id) {
+        Some(i) => i,
+        None => return,
+    };
+    let bus_name = item.bus_name.clone();
+    let menu_path = item.menu_path.clone();
+    let dmenu_cmd = ss
+        .config
+        .menu_command
+        .clone()
+        .unwrap_or_else(|| "dmenu".to_owned());
+
+    // Spawn dmenu in a thread
+    std::thread::spawn(move || {
+        if let Err(e) = run_dmenu_loop(&dmenu_cmd, &bus_name, &menu_path, &nodes) {
+            eprintln!("tray menu error: {e}");
+        }
+    });
+}
+
+/// Run the dmenu loop. Shows menus and submenus until the user cancels or selects a leaf.
+fn run_dmenu_loop(
+    dmenu_cmd: &str,
+    bus_name: &str,
+    menu_path: &str,
+    nodes: &[MenuNode],
+) -> anyhow::Result<()> {
+    let mut current_nodes = nodes.to_vec();
+
+    loop {
+        let visible: Vec<&MenuNode> = current_nodes
+            .iter()
+            .filter(|n| n.visible && !n.label.is_empty())
+            .collect();
+        if visible.is_empty() {
+            return Ok(());
+        }
+
+        let selection = match show_dmenu(dmenu_cmd, &visible) {
+            Some(s) => s,
+            None => return Ok(()), // user cancelled
+        };
+
+        let selected = match visible.iter().find(|n| n.label == selection) {
+            Some(n) => n,
+            None => return Ok(()),
+        };
+
+        if selected.is_submenu && !selected.children.is_empty() {
+            current_nodes = selected.children.clone();
+        } else {
+            rustsni::fire_menu_click(bus_name, menu_path, selected.id)?;
+            return Ok(());
+        }
+    }
+}
+
+/// Show dmenu with the given menu items. Returns the selected label or None.
+fn show_dmenu(cmd: &str, items: &[&MenuNode]) -> Option<String> {
+    use std::io::Write;
+    use std::process::{Command, Stdio};
+
+    // Split command into program and args
+    let parts: Vec<&str> = cmd.split_whitespace().collect();
+    if parts.is_empty() {
+        return None;
+    }
+    let mut builder = Command::new(parts[0]);
+    for arg in &parts[1..] {
+        builder.arg(arg);
+    }
+
+    let mut child = builder
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .ok()?;
+
+    {
+        let stdin = child.stdin.as_mut()?;
+        for item in items {
+            let label = if item.enabled {
+                &item.label
+            } else {
+                // Mark disabled items
+                &format!("({})", item.label)
+            };
+            let _ = writeln!(stdin, "{label}");
+        }
+    }
+
+    let output = child.wait_with_output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let line = String::from_utf8_lossy(&output.stdout);
+    let trimmed = line.trim().to_owned();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn slot_size(full_height: f64) -> f64 {
+    (full_height - 4.0).max(16.0)
+}
+
+const PAD: f64 = 4.0;
+
+/// Render tray icons.
+pub fn render(
+    context: &cairo::Context,
+    ss: &SharedState,
+    btns: &mut ButtonManager<String>,
+    start_x: f64,
+    full_height: f64,
+    scale_f: f64,
+) {
+    if ss.tray_cache.is_empty() {
+        return;
+    }
+
+    btns.clear();
+
+    let mut ordered: Vec<(&String, &CachedIcon)> = ss.tray_cache.iter().collect();
+    ordered.sort_by(|a, b| a.0.cmp(b.0));
+
+    let slot = slot_size(full_height);
+    let phys_slot = slot * scale_f;
+    let phys_full_height = full_height * scale_f;
+    let phys_pad = PAD * scale_f;
+    let mut phys_x = start_x * scale_f;
+    let mut logical_x = start_x;
+
+    context.save().unwrap();
+    context.identity_matrix();
+
+    for (id, icon) in &ordered {
+        // Compute scale factor to fit icon within the slot (preserving aspect ratio)
+        let fit = ((slot * scale_f) / icon.w as f64).min((full_height * scale_f) / icon.h as f64);
+
+        // Premultiply alpha — Cairo ARGB32 format requires premultiplied alpha
+        let mut icon_data = icon.data.clone();
+        for pixel in icon_data.chunks_exact_mut(4) {
+            let a = pixel[3] as u32;
+            pixel[0] = (pixel[0] as u32 * a / 255) as u8;
+            pixel[1] = (pixel[1] as u32 * a / 255) as u8;
+            pixel[2] = (pixel[2] as u32 * a / 255) as u8;
+        }
+
+        let display_w = icon.w as f64 * fit;
+        let display_h = icon.h as f64 * fit;
+        let draw_x = phys_x + (phys_slot - display_w) / 2.0;
+        let draw_y = (phys_full_height - display_h) / 2.0;
+
+        let stride = (icon.w * 4) as i32;
+        // SAFETY: Cairo only reads the data during paint.
+        let surf = unsafe {
+            match cairo::ImageSurface::create_for_data_unsafe(
+                icon_data.as_ptr() as *mut u8,
+                cairo::Format::ARgb32,
+                icon.w as i32,
+                icon.h as i32,
+                stride,
+            ) {
+                Ok(s) => s,
+                Err(_) => {
+                    phys_x += phys_slot + phys_pad;
+                    logical_x += slot + PAD;
+                    continue;
+                }
+            }
+        };
+
+        context.save().unwrap();
+        context.rectangle(phys_x, 0.0, phys_slot, phys_full_height);
+        context.clip();
+        context.translate(draw_x, draw_y);
+        context.scale(fit, fit);
+        context.set_source_surface(&surf, 0.0, 0.0).unwrap();
+        context.source().set_filter(cairo::Filter::Best);
+        context.paint().unwrap();
+        context.restore().unwrap();
+
+        drop(surf);
+
+        btns.push(logical_x, slot, (*id).clone());
+        phys_x += phys_slot + phys_pad;
+        logical_x += slot + PAD;
+    }
+
+    context.restore().unwrap();
+}
+
+/// Resolve a tray item's icon to a native-endian ARGB32 pixel buffer.
+/// Returns the raw pixmap at its native size — all scaling is done at render time.
+fn resolve_icon(item: &TrayItem, max_h: u32) -> Option<(Vec<u8>, u32, u32)> {
+    // `max_h` is only used by `resolve_icon_name` for the freedesktop-icons lookup size.
+    // Raw pixmaps from D-Bus are used at their native resolution.
+
+    // When requesting attention, prefer attention icon, but fall back
+    // to the regular icon if the item doesn't provide a separate one.
+    if item.status == "NeedsAttention" {
+        if let Some(best) = item.best_attention_icon_pixmap() {
+            return Some((best.data.clone(), best.width, best.height));
+        }
+        if let Some(result) = resolve_icon_name(&item.attention_icon_name, item, max_h) {
+            return Some(result);
+        }
+        // No attention icon — fall through to regular icon below
+    }
+
+    // 1. Try raw pixmaps — pick the largest available
+    if let Some(best) = item.best_icon_pixmap() {
+        return Some((best.data.clone(), best.width, best.height));
+    }
+
+    // 2. Try icon name — absolute path or theme lookup
+    if let Some(result) = resolve_icon_name(&item.icon_name, item, max_h) {
+        return Some(result);
+    }
+
+    None
+}
+
+/// Try to load an icon by name. Checks icon_theme_path first, then system theme.
+fn resolve_icon_name(name: &str, item: &TrayItem, max_h: u32) -> Option<(Vec<u8>, u32, u32)> {
+    if name.is_empty() {
+        return None;
+    }
+    if name.starts_with('/') {
+        return load_image_path(name);
+    }
+    // Check icon_theme_path directly (app-bundled icons)
+    for search_path in item.icon_search_paths() {
+        let candidate = format!("{search_path}/{name}.png");
+        if let Some(result) = load_image_path(&candidate) {
+            return Some(result);
+        }
+    }
+    // Fall back to system icon theme — request oversized source for sharp downscale
+    let request_size = (max_h * 2).clamp(32, 256) as u16;
+    let path = freedesktop_icons::lookup(name)
+        .with_size(request_size)
+        .with_cache()
+        .find()?;
+    load_image_path(path.to_str()?)
+}
+
+/// Load an image file at its native size, return as Cairo ARgb32 buffer.
+fn load_image_path(path: &str) -> Option<(Vec<u8>, u32, u32)> {
+    let mut file = File::open(path).ok()?;
+    let mut surf = cairo::ImageSurface::create_from_png(&mut file).ok()?;
+    let w = surf.width() as u32;
+    let h = surf.height() as u32;
+    let data = surf.data().ok()?.to_vec();
+    Some((data, w, h))
+}


### PR DESCRIPTION
This is an implementation of #7, based on the [rustsni](https://crates.io/crates/rustsni) library (built on rustbus — synchronous, non-blocking), which integrates naturally with the existing poll-based event loop.

## What this does
- Auto-discovers tray items via D-Bus (StatusNotifierItem protocol)
- Renders icons centered in their slots, with the tray as a whole right-aligned on the bar; supports HiDPI scaling
- Left-click: activates the tray item (Activate), or shows menu if item is menu-only
- Right-click: shows context menu via a configurable `menu_command` (defaults to `dmenu`)
- Degrades gracefully when no tray items exist or D-Bus is unavailable — zero impact on normal bar operation

## New dependencies
- `rustsni` — StatusNotifierItem host-side implementation (rustbus ecosystem, no tokio dependency)
- `freedesktop-icons` — icon lookup via freedesktop icon themes
- `cairo-rs` (png feature) — PNG loading for tray icons

## New config option
- `menu_command` — optional, the command to use for tray context menus (e.g. `"rofi -dmenu"`). Defaults to `"dmenu"`.